### PR TITLE
GLOB-38241 support string values for memcached timeout

### DIFF
--- a/src/__tests__/memcached-promisify.test.js
+++ b/src/__tests__/memcached-promisify.test.js
@@ -13,7 +13,10 @@ jest.mock('@globality/nodule-config', () => ({
 }));
 jest.mock('memcached');
 
+/* eslint-disable no-new */
+
 const cache = new Cache({ maxExpiration: 900, hosts: 'localhost:11211' });
+
 describe('memcached promisify', () => {
     beforeEach(() => {
         Memcached.mockClear();
@@ -39,7 +42,7 @@ describe('memcached promisify', () => {
             {
                 hosts: 'localhost:11211',
                 maxExpiration: 2592000, // 30 days
-            }
+            },
         );
     });
 
@@ -50,7 +53,7 @@ describe('memcached promisify', () => {
 
         expect(Memcached).toHaveBeenCalledWith(
             ['localhost:11211', 'localhost:11212'],
-            { hosts }
+            { hosts },
         );
     });
 
@@ -65,7 +68,7 @@ describe('memcached promisify', () => {
             {
                 hosts: 'localhost:11211',
                 timeout: 100,
-            }
+            },
         );
     });
 

--- a/src/memcached-promisify.js
+++ b/src/memcached-promisify.js
@@ -33,7 +33,11 @@ class Cache {
         maxExpiration: MAX_EXPIRATION,
         hosts: DEFAULT_HOST,
     }) {
+        // Cast the timeout option to a number to avoid errors from `memcached`
         if (options.timeout) {
+            // parameter reassignment safer than trying to copy the option bag
+            // TODO: do this properly and avoid passing unknown options through
+            // eslint-disable-next-line no-param-reassign
             options.timeout = parseInt(options.timeout, 10);
         }
 

--- a/src/memcached-promisify.js
+++ b/src/memcached-promisify.js
@@ -20,19 +20,23 @@ function cachePromise(cache, method, ...args) {
 
 /**
  * Cache
+ *
  * @constructor
- * @param {string} [cacheHost] - cache host url
- * @param {Object} [options] - options passed to memcached
+ * @param {Object} options - options passed to memcached
+ * @param {string} options.hosts - comma-separated list of memcached hosts
  *
  * @example
- *    new Cache('host', { maxExpiration: 900 });
- *
+ *    new Cache({ hosts: 'host1,host2', maxExpiration: 900 });
  */
 class Cache {
     constructor(options = {
         maxExpiration: MAX_EXPIRATION,
         hosts: DEFAULT_HOST,
     }) {
+        if (options.timeout) {
+            options.timeout = parseInt(options.timeout, 10);
+        }
+
         this.maxExpiration = options.maxExpiration;
         const hosts = options.hosts.split(',');
         this.client = new Memcached(hosts, options);


### PR DESCRIPTION
Part of [GLOB-38241]

We'd like to be able to reduce the memcached `timeout` (if it's failing then we skip the cache and just rerequest the value we need). This value comes in as an environment variable as a string, but Node's `Stream` blows up as it expects a number.

This commit:

* makes sure the `timeout` is numeric if it exists
* corrects the constructor signature in the docblock
* adds a couple more tests

[GLOB-38241]: https://globality.atlassian.net/browse/GLOB-38241