### PR TITLE
Release/0.1.3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.3
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-memcached",
-    "version": "0.1.1",
+    "version": "0.1.3",
     "description": "Node memcached client",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",


### PR DESCRIPTION
Version `0.1.2` is already on `master`, so jump forward to `0.1.3`.