### PR TITLE
Release/0.1.3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.3
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-memcached",
-    "version": "0.1.1",
+    "version": "0.1.3",
     "description": "Node memcached client",
     "main": "lib/",
     "repository": "git@github.com:globality-corp/nodule-graphql",

--- a/src/__tests__/memcached-promisify.test.js
+++ b/src/__tests__/memcached-promisify.test.js
@@ -1,3 +1,5 @@
+import Memcached from 'memcached';
+
 import Cache from '../memcached-promisify';
 
 const mockConfig = {
@@ -9,15 +11,65 @@ const mockConfig = {
 jest.mock('@globality/nodule-config', () => ({
     getContainer: () => (mockConfig),
 }));
+jest.mock('memcached');
+
+/* eslint-disable no-new */
 
 const cache = new Cache({ maxExpiration: 900, hosts: 'localhost:11211' });
+
 describe('memcached promisify', () => {
+    beforeEach(() => {
+        Memcached.mockClear();
+    });
+
     it('should have various methods', () => {
         expect(cache.get).toBeDefined();
         expect(cache.getMulti).toBeDefined();
         expect(cache.set).toBeDefined();
         expect(cache.add).toBeDefined();
         expect(cache.del).toBeDefined();
+    });
+
+    it('should create a memcached client', () => {
+        new Cache();
+        expect(Memcached).toHaveBeenCalled();
+    });
+
+    it('should set sensible default values', () => {
+        new Cache();
+        expect(Memcached).toHaveBeenCalledWith(
+            ['localhost:11211'],
+            {
+                hosts: 'localhost:11211',
+                maxExpiration: 2592000, // 30 days
+            },
+        );
+    });
+
+    it('can support multiple hosts', () => {
+        const hosts = 'localhost:11211,localhost:11212';
+
+        new Cache({ hosts });
+
+        expect(Memcached).toHaveBeenCalledWith(
+            ['localhost:11211', 'localhost:11212'],
+            { hosts },
+        );
+    });
+
+    it('should cast timeout to a number', () => {
+        new Cache({
+            hosts: 'localhost:11211',
+            timeout: '100',
+        });
+
+        expect(Memcached).toHaveBeenCalledWith(
+            ['localhost:11211'],
+            {
+                hosts: 'localhost:11211',
+                timeout: 100,
+            },
+        );
     });
 
     xdescribe('execute methods', () => {

--- a/src/memcached-promisify.js
+++ b/src/memcached-promisify.js
@@ -20,19 +20,27 @@ function cachePromise(cache, method, ...args) {
 
 /**
  * Cache
+ *
  * @constructor
- * @param {string} [cacheHost] - cache host url
- * @param {Object} [options] - options passed to memcached
+ * @param {Object} options - options passed to memcached
+ * @param {string} options.hosts - comma-separated list of memcached hosts
  *
  * @example
- *    new Cache('host', { maxExpiration: 900 });
- *
+ *    new Cache({ hosts: 'host1,host2', maxExpiration: 900 });
  */
 class Cache {
     constructor(options = {
         maxExpiration: MAX_EXPIRATION,
         hosts: DEFAULT_HOST,
     }) {
+        // Cast the timeout option to a number to avoid errors from `memcached`
+        if (options.timeout) {
+            // parameter reassignment safer than trying to copy the option bag
+            // TODO: do this properly and avoid passing unknown options through
+            // eslint-disable-next-line no-param-reassign
+            options.timeout = parseInt(options.timeout, 10);
+        }
+
         this.maxExpiration = options.maxExpiration;
         const hosts = options.hosts.split(',');
         this.client = new Memcached(hosts, options);


### PR DESCRIPTION
Version `0.1.2` is already on `master`, so jump forward to `0.1.3`.